### PR TITLE
github: Use `Literal` types for string arguments

### DIFF
--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 import httpx
 from lutraai.augmented_request_client import AugmentedTransport
@@ -24,7 +24,7 @@ class PullRequest:
 def github_pulls(
     owner: str,
     repo: str,
-    state: str = "open",
+    state: Literal["open", "closed", "all"] = "open",
     sort: str = "created",
     sort_direction: str | None = None,
     page: int = 1,

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -26,7 +26,7 @@ def github_pulls(
     owner: str,
     repo: str,
     state: Literal["open", "closed", "all"] = "open",
-    sort: str = "created",
+    sort: Literal["created", "updated", "popularity", "long-running"] = "created",
     sort_direction: str | None = None,
     page: int = 1,
 ) -> list[PullRequest]:

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -27,7 +27,7 @@ def github_pulls(
     repo: str,
     state: Literal["open", "closed", "all"] = "open",
     sort: Literal["created", "updated", "popularity", "long-running"] = "created",
-    sort_direction: str | None = None,
+    sort_direction: Literal["asc", "desc"] | None = None,
     page: int = 1,
 ) -> list[PullRequest]:
     """
@@ -42,9 +42,8 @@ def github_pulls(
         repo: the repository name.
         state: may be one of {"open","closed","all"}.
         sort: by what to sort results.
-            One of {"created","updated","popularity","long-running"}.
-        sort_direction: the direction of the sort.  One of {"asc","desc"}.  If None,
-            "desc" for sort by "created", "asc" otherwise.
+        sort_direction: the direction of the sort.  If None, "desc" for sort by
+            "created", "asc" otherwise.
         page: the page of results to return. Each page has at most 30 results.
 
     """

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1,6 +1,5 @@
 import httpx
 from dataclasses import dataclass
-from typing import List
 
 from lutraai.augmented_request_client import AugmentedTransport
 
@@ -24,7 +23,7 @@ def github_pulls(
     sort: str = "created",
     sort_direction: str | None = None,
     page: int = 1,
-) -> List[PullRequest]:
+) -> list[PullRequest]:
     """
     Returns results of a GitHub `pulls` API call.
 

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1,7 +1,8 @@
-import httpx
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Optional
 
+import httpx
 from lutraai.augmented_request_client import AugmentedTransport
 
 
@@ -10,8 +11,8 @@ class PullRequest:
     id: int
     html_url: str
     created_at: datetime
-    merged_at: datetime | None
-    closed_at: datetime | None
+    merged_at: Optional[datetime]
+    closed_at: Optional[datetime]
     title: str
     state: str
     draft: bool

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1,5 +1,6 @@
 import httpx
 from dataclasses import dataclass
+from datetime import datetime
 
 from lutraai.augmented_request_client import AugmentedTransport
 
@@ -8,6 +9,9 @@ from lutraai.augmented_request_client import AugmentedTransport
 class PullRequest:
     id: int
     html_url: str
+    created_at: datetime
+    merged_at: datetime | None
+    closed_at: datetime | None
     title: str
     state: str
     draft: bool
@@ -59,6 +63,13 @@ def github_pulls(
         PullRequest(
             id=obj["id"],
             html_url=obj["html_url"],
+            created_at=datetime.fromisoformat(obj["created_at"]),
+            merged_at=(
+                datetime.fromisoformat(obj["merged_at"]) if "merged_at" in obj else None
+            ),
+            closed_at=(
+                datetime.fromisoformat(obj["closed_at"]) if "closed_at" in obj else None
+            ),
             title=obj["title"],
             state=obj["state"],
             draft=obj["draft"],

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1,6 +1,6 @@
 import httpx
 from dataclasses import dataclass
-from typing import Any, List
+from typing import List
 
 from lutraai.augmented_request_client import AugmentedTransport
 


### PR DESCRIPTION
Use `Literal` types for string arguments to help guide correct calling.