### PR TITLE
airtable: Include schema in 422 error messages

### DIFF
--- a/README.external.md
+++ b/README.external.md
@@ -250,9 +250,6 @@ class Bar:
     foo: Foo
 ```
 
-TODO: Dataclasses can't actually refer to other dataclasses right now, but I am
-about to make a PR that supports this feature.
-
 However, recursive dataclass definitions are disallowed, e.g.:
 
 ```python

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -17,6 +17,7 @@ class AirtableRecord:
 def airtable_record_list(baseId: str, tableIdOrName: str) -> list[AirtableRecord]:
     """
     Return results of an Airtable `list records` API call.
+    baseId must be an ID and not a name.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
@@ -41,6 +42,8 @@ def airtable_record_update_patch(
 ) -> None:
     """
     Update a record using the Airtable `update record` API call with a PATCH.
+    baseId must be an ID and not a name.
+    recordId must be an ID and not a name.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -37,6 +37,31 @@ def airtable_record_list(baseId: str, tableIdOrName: str) -> list[AirtableRecord
     ]
 
 
+def airtable_record_create(
+    baseId: str, tableIdOrName: str, fields: dict[str, Any]
+) -> AirtableRecord:
+    """
+    Create a record using the Airtable `create records` API call with a POST.
+    baseId must be an ID and not a name.
+    """
+    with httpx.Client(
+        transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
+    ) as client:
+        data = (
+            client.post(
+                f"https://api.airtable.com/v0/{baseId}/{tableIdOrName}",
+                json={"fields": fields},
+            )
+            .raise_for_status()
+            .json()
+        )
+    return AirtableRecord(
+        id=data["id"],
+        created_time=datetime.fromisoformat(data["createdTime"]),
+        fields=data["fields"],
+    )
+
+
 def airtable_record_update_patch(
     baseId: str, tableIdOrName: str, recordId: str, fields: dict[str, Any]
 ) -> None:

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -41,6 +41,13 @@ def _resolve_error_message(
     status_code: int,
     text: str,
 ) -> str:
+    """
+    Returns a more human-readable error message from semi-structured error responses.
+    If the error is a 422, try to include the schema of the table in the error message.
+
+    See examples here:
+    https://airtable.com/developers/web/api/errors#example-error-responses
+    """
     msg, include_schema = _resolve_error_message_no_schema(status_code, text)
     if include_schema:
         try:

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -14,6 +14,9 @@ def _resolve_error_message_no_schema(status_code: int, text: str) -> tuple[str, 
 
     See examples here:
     https://airtable.com/developers/web/api/errors#example-error-responses
+
+    The first element of the tuple is the error message.  The second element is a
+    bool judgement whether the error message would benefit from schema information.
     """
     prefix = f"{status_code} {httpx.codes.get_reason_phrase(status_code)}: "
     include_schema = status_code == httpx.codes.UNPROCESSABLE_ENTITY

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -8,33 +8,75 @@ import httpx
 from lutraai.augmented_request_client import AugmentedTransport
 
 
-def _resolve_error_message(status_code: int, text: str) -> str:
+def _resolve_error_message_no_schema(status_code: int, text: str) -> tuple[str, bool]:
     """
     Returns a more human-readable error message from semi-structured error responses.
 
     See examples here:
     https://airtable.com/developers/web/api/errors#example-error-responses
     """
+    include_schema = status_code == httpx.codes.UNPROCESSABLE_ENTITY
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
-        return text
+        return text, include_schema
     match (error := data.get("error")):
         case str():
             return (
-                f"{status_code} {httpx.codes.get_reason_phrase(status_code)}: {error}"
+                f"{status_code} {httpx.codes.get_reason_phrase(status_code)}: {error}",
+                include_schema,
             )
         case dict():
             error_type = error.get("type")
             error_message = error.get("message")
             if not isinstance(error_type, str) or not isinstance(error_message, str):
-                return text
+                return text, include_schema
             return (
-                f"{status_code} {httpx.codes.get_reason_phrase(status_code)}: "
-                f"{error_type}: {error_message}"
+                (
+                    f"{status_code} {httpx.codes.get_reason_phrase(status_code)}: "
+                    f"{error_type}: {error_message}"
+                ),
+                include_schema,
             )
         case _:
-            return text
+            return text, include_schema
+
+
+def _resolve_error_message(
+    client: httpx.Client,
+    base_id: str,
+    table_id_or_name: str,
+    status_code: int,
+    text: str,
+) -> str:
+    msg, include_schema = _resolve_error_message_no_schema(status_code, text)
+    if include_schema:
+        try:
+            data = (
+                client.get(f"https://api.airtable.com/v0/meta/bases/{base_id}/tables")
+                .raise_for_status()
+                .json()
+            )
+            table_id_names = []
+            for table in data["tables"]:
+                table_id_names.append(f"{table['id']}({table['name']})")
+            schema = None
+            for table in data["tables"]:
+                if table["id"] == table_id_or_name:
+                    schema = table["fields"]
+            if not schema:
+                for table in data["tables"]:
+                    if table["name"] == table_id_or_name:
+                        schema = table["fields"]
+            if not schema:
+                return (
+                    f"{msg}; {table_id_or_name} not found in "
+                    f"tables: {sorted(table_id_names)}"
+                )
+            return f"{msg}; schema of table `{table_id_or_name}`: {json.dumps(schema)}"
+        except Exception as e:
+            return f"{msg}; (error fetching schema of {table_id_or_name}: {e})"
+    return msg
 
 
 @dataclass
@@ -44,19 +86,22 @@ class AirtableRecord:
     fields: dict[str, Any]
 
 
-def airtable_record_list(baseId: str, tableIdOrName: str) -> list[AirtableRecord]:
+def airtable_record_list(base_id: str, table_id_or_name: str) -> list[AirtableRecord]:
     """
     Return results of an Airtable `list records` API call.
-    baseId must be an ID and not a name.
+    base_id must be an ID and not a name.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
     ) as client:
-        data = (
-            client.get(f"https://api.airtable.com/v0/{baseId}/{tableIdOrName}")
-            .raise_for_status()
-            .json()
+        response = client.get(
+            f"https://api.airtable.com/v0/{base_id}/{table_id_or_name}"
         )
+        if response.status_code != httpx.codes.OK:
+            raise RuntimeError(
+                _resolve_error_message_no_schema(response.status_code, response.text)
+            )
+        data = response.json()
     return [
         AirtableRecord(
             id=record["id"],
@@ -68,22 +113,28 @@ def airtable_record_list(baseId: str, tableIdOrName: str) -> list[AirtableRecord
 
 
 def airtable_record_create(
-    baseId: str, tableIdOrName: str, fields: dict[str, Any]
+    base_id: str, table_id_or_name: str, fields: dict[str, Any]
 ) -> AirtableRecord:
     """
     Create a record using the Airtable `create records` API call with a POST.
-    baseId must be an ID and not a name.
+    base_id must be an ID and not a name.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
     ) as client:
         response = client.post(
-            f"https://api.airtable.com/v0/{baseId}/{tableIdOrName}",
+            f"https://api.airtable.com/v0/{base_id}/{table_id_or_name}",
             json={"fields": fields},
         )
         if response.status_code != httpx.codes.OK:
             raise RuntimeError(
-                _resolve_error_message(response.status_code, response.text)
+                _resolve_error_message(
+                    client,
+                    base_id,
+                    table_id_or_name,
+                    response.status_code,
+                    response.text,
+                )
             )
         data = response.json()
     return AirtableRecord(
@@ -94,21 +145,27 @@ def airtable_record_create(
 
 
 def airtable_record_update_patch(
-    baseId: str, tableIdOrName: str, recordId: str, fields: dict[str, Any]
+    base_id: str, table_id_or_name: str, record_id: str, fields: dict[str, Any]
 ) -> None:
     """
     Update a record using the Airtable `update record` API call with a PATCH.
-    baseId must be an ID and not a name.
-    recordId must be an ID and not a name.
+    base_id must be an ID and not a name.
+    record_id must be an ID and not a name.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
     ) as client:
         response = client.patch(
-            f"https://api.airtable.com/v0/{baseId}/{tableIdOrName}/{recordId}",
+            f"https://api.airtable.com/v0/{base_id}/{table_id_or_name}/{record_id}",
             json={"fields": fields},
         )
         if response.status_code != httpx.codes.OK:
             raise RuntimeError(
-                _resolve_error_message(response.status_code, response.text)
+                _resolve_error_message(
+                    client,
+                    base_id,
+                    table_id_or_name,
+                    response.status_code,
+                    response.text,
+                )
             )


### PR DESCRIPTION
When we get a `422 Unprocessable Entity` error, try to fetch the involved table schema and include it in the error message.  This is both useful to humans and to LLMs, hopefully making it possible for things to fix themselves.