### PR TITLE
airtable: Improve URL parsing

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -1,51 +1,65 @@
 import json
+import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Tuple
-import re
+from typing import Any, Optional, Tuple
+from urllib.parse import urlparse
 
 import httpx
-
 from lutraai.augmented_request_client import AugmentedTransport
+
 
 @dataclass
 class AirtableBaseID:
     id: str
+
 
 @dataclass
 class AirtableTableID:
     """
     id can either be the table name or the table ID.
     """
+
     id: str
+
 
 @dataclass
 class AirtableRecordID:
     id: str
 
 
-def airtable_url_to_ids(url: str) -> Tuple[AirtableBaseID, AirtableTableID]:
+def airtable_parse_ids_from_url(
+    url: str,
+) -> Tuple[AirtableBaseID, Optional[AirtableTableID], Optional[AirtableRecordID]]:
     """
-    Extracts the base ID and table ID from an Airtable URL.
+    Parse Airtable IDs from an Airtable web UI URL.  url must be in the format
+    "https://airtable.com/{base_id}/{table_id}/{view_id}/{record_id}" and may include
+    additional path segments or query arguments after the record ID which will be
+    ignored.
+
+    Only the base_id is required and guaranteed to be non-None.  For each other ID, if
+    it is not present in the URL, the corresponding value in the tuple will be None.
+    You must check that these ID values are not None before using them.
     """
-    # Regular expression to extract base and table IDs
-    # This pattern is flexible to accommodate prefixes before 'airtable.com'
-    pattern = r"airtable\.com/([^/?]+)(?:/([^/?]+))?"
-    match = re.search(pattern, url)
+    parsed_url = urlparse(url)
 
-    if not match:
-        raise ValueError("Invalid Airtable URL")
+    if parsed_url.netloc != "airtable.com":
+        raise ValueError(f"host must be airtable.com: {url}")
 
-    base_id = match.group(1)
-    # When loading the Airtable using the URL that only has the base id (e.g. https://airtable.com/apptpbyiHjjfPecFw)
-    # Airtable automatically drops you into the first table of the base and we don't expect the table_id to be an empty string
-    # if the user copies the URL from the browser.
-    if not match.group(2):
-        raise ValueError("Invalid Airtable table ID")
+    pattern = r"/(?P<base_id>app[\w\d]+)(?:/(?P<table_id>tbl[\w\d]+))?(?:/(?P<view_id>viw[\w\d]+))?(?:/(?P<record_id>rec[\w\d]+))?(?:/.*)?"
+    match = re.search(pattern, parsed_url.path)
+    if match:
+        base_id = match.group("base_id")
+        table_id = match.group("table_id")
+        record_id = match.group("record_id")
+        return (
+            AirtableBaseID(base_id),
+            AirtableTableID(table_id) if table_id else None,
+            AirtableRecordID(record_id) if record_id else None,
+        )
+    else:
+        raise ValueError(f"does not match the expected Airtable URL format: {url}")
 
-    table_id = match.group(2)
-
-    return (AirtableBaseID(base_id), AirtableTableID(table_id))
 
 def _resolve_error_message_no_schema(status_code: int, text: str) -> tuple[str, bool]:
     """
@@ -127,16 +141,16 @@ class AirtableRecord:
     fields: dict[str, Any]
 
 
-def airtable_record_list(base_id: AirtableBaseID, table_id: AirtableTableID) -> list[AirtableRecord]:
+def airtable_record_list(
+    base_id: AirtableBaseID, table_id: AirtableTableID
+) -> list[AirtableRecord]:
     """
     Return results of an Airtable `list records` API call.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
     ) as client:
-        response = client.get(
-            f"https://api.airtable.com/v0/{base_id.id}/{table_id.id}"
-        )
+        response = client.get(f"https://api.airtable.com/v0/{base_id.id}/{table_id.id}")
         if response.status_code != httpx.codes.OK:
             raise RuntimeError(
                 _resolve_error_message_no_schema(response.status_code, response.text)
@@ -153,7 +167,10 @@ def airtable_record_list(base_id: AirtableBaseID, table_id: AirtableTableID) -> 
 
 
 def airtable_record_create(
-    base_id: AirtableBaseID, table_id: AirtableTableID, fields: dict[str, Any], typecast: bool = True,
+    base_id: AirtableBaseID,
+    table_id: AirtableTableID,
+    fields: dict[str, Any],
+    typecast: bool = True,
 ) -> AirtableRecord:
     """
     Create a record using the Airtable `create records` API call with a POST.
@@ -186,7 +203,11 @@ def airtable_record_create(
 
 
 def airtable_record_update_patch(
-    base_id: AirtableBaseID, table_id: AirtableTableID, record_id: AirtableRecordID, fields: dict[str, Any], typecast: bool = True
+    base_id: AirtableBaseID,
+    table_id: AirtableTableID,
+    record_id: AirtableRecordID,
+    fields: dict[str, Any],
+    typecast: bool = True,
 ) -> None:
     """
     Update a record using the Airtable `update record` API call with a PATCH and override the fields it is patching.

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -42,10 +42,8 @@ def airtable_parse_ids_from_url(
     You must check that these ID values are not None before using them.
     """
     parsed_url = urlparse(url)
-
     if parsed_url.netloc != "airtable.com":
         raise ValueError(f"host must be airtable.com: {url}")
-
     pattern = r"/(?P<base_id>app[\w\d]+)(?:/(?P<table_id>tbl[\w\d]+))?(?:/(?P<view_id>viw[\w\d]+))?(?:/(?P<record_id>rec[\w\d]+))?(?:/.*)?"
     match = re.search(pattern, parsed_url.path)
     if match:

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import httpx
 from lutraai.augmented_request_client import AugmentedTransport
@@ -44,8 +44,10 @@ def airtable_parse_ids_from_url(
     parsed_url = urlparse(url)
     if parsed_url.netloc != "airtable.com":
         raise ValueError(f"host must be airtable.com: {url}")
-    pattern = r"/(?P<base_id>app[\w\d]+)(?:/(?P<table_id>tbl[\w\d]+))?(?:/(?P<view_id>viw[\w\d]+))?(?:/(?P<record_id>rec[\w\d]+))?(?:/.*)?"
-    match = re.search(pattern, parsed_url.path)
+    match = re.search(
+        r"/(?P<base_id>app[\w\d]+)(?:/(?P<table_id>tbl[\w\d]+))?(?:/(?P<view_id>viw[\w\d]+))?(?:/(?P<record_id>rec[\w\d]+))?(?:/.*)?",
+        unquote(parsed_url.path),
+    )
     if match:
         base_id = match.group("base_id")
         table_id = match.group("table_id")


### PR DESCRIPTION
Improve URL parsing in a few ways:
- Add support for parsing record IDs.  This makes it possible/easy to write a workflow like: `Update the "Name" field of an Airtable record (given by the URL of the record) to a customizable name.`
- Provide a format for the expected input.  This seems to help avoid workflow argument examples that are API URLs like `https://api.airtable.com`.
- Now that it can optionally parse out IDs, return optional IDs.  The docstring explicitly mentions that the optional values be checked for non-`None` before use.  This helps avoid a first (failing) pass that fails to type-check because the returned IDs are used without validating.
- Use `urllib.parse` to parse URLs because... they are URLs.  Unquote the path to handle any encoding shenanigans.
- Rename to `airtable_parse_ids_from_url`.  This seems to help code generation use it correctly, e.g. to either use it for all needed all IDs or not, as opposed to asking for a URL for the base and separately asking for a table ID -- I'm not sure why this would be, but that's what it seemed like to me.

Note that because of non-determinism, it's hard to have 100% confidence that this is a strict improvement, but it qualitatively seems a lot better to me.