### PR TITLE
webhook: Add initial webhook plugin

### DIFF
--- a/webhook/plugin.py
+++ b/webhook/plugin.py
@@ -3,6 +3,12 @@ from typing import Any
 import httpx
 
 
-async def webhook_request(url: str, body: dict[str, Any]) -> Any:
+async def webhook_request(url: str, body: Any) -> Any:
+    """
+    Makes a POST request to the given URL with the given body and returns the response.
+
+    Both the request and response bodies are expected to be JSON and are converted to
+    Python values using the json module.
+    """
     async with httpx.AsyncClient() as client:
         return await client.post(url, json=body).raise_for_status().json()

--- a/webhook/plugin.py
+++ b/webhook/plugin.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+import httpx
+
+
+async def webhook_request(url: str, body: dict[str, Any]) -> Any:
+    async with httpx.AsyncClient() as client:
+        return await client.post(url, json=body).raise_for_status().json()

--- a/webhook/plugin.py
+++ b/webhook/plugin.py
@@ -5,7 +5,7 @@ import httpx
 
 async def webhook_request(url: str, body: Any) -> Any:
     """
-    Makes a POST request to the given URL with the given body and returns the response.
+    Make a POST request to the given URL with the given body and returns the response.
 
     Both the request and response bodies are expected to be JSON and are converted to
     Python values using the json module.

--- a/webhook/plugin.py
+++ b/webhook/plugin.py
@@ -11,4 +11,4 @@ async def webhook_request(url: str, body: Any) -> Any:
     Python values using the json module.
     """
     async with httpx.AsyncClient() as client:
-        return await client.post(url, json=body).raise_for_status().json()
+        return (await client.post(url, json=body)).raise_for_status().json()

--- a/webhook/plugin.py
+++ b/webhook/plugin.py
@@ -8,7 +8,7 @@ async def webhook_request(url: str, body: Any) -> Any:
     Make a POST request to the given URL with the given body and returns the response.
 
     Both the request and response bodies are expected to be JSON and are converted to
-    Python values using the json module.
+    and from Python values using the json module.
     """
     async with httpx.AsyncClient() as client:
         return (await client.post(url, json=body)).raise_for_status().json()

--- a/webhook/plugin.toml
+++ b/webhook/plugin.toml
@@ -1,3 +1,2 @@
 name = "Webhook"
 description = "Use external webhooks."
-# logo_url = "/assets/logos/airtable.svg"

--- a/webhook/plugin.toml
+++ b/webhook/plugin.toml
@@ -1,0 +1,3 @@
+name = "Webhook"
+description = "Use external webhooks."
+# logo_url = "/assets/logos/airtable.svg"


### PR DESCRIPTION
This initial plugin implementation is very simple.  It does a bunch of simplifying things:
- Assumes `POST`.
- Assumes JSON request and response bodies.
- `body` and return are `Any`, so we won't get much typing help.

This is good enough to be used by a workflow with the description:
> Post a body of the form { "message": "Hello from Lutra and Zapier!"} to the webhook `https://hooks.zapier.com/hooks/catch/<elided>`. Allow only the message to be customizable.