### PR TITLE
airtable: Allow specification of what fields to include

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -157,11 +157,11 @@ def airtable_record_list(
     """
     Return results of an Airtable `list records` API call with the option of choosing
     which fields to include in the returned records.  The include_fields fields are
-    required, so populate it ensure that the returned records have the fields you will
-    access by name.
+    required, so populate it to ensure that the returned records have the fields you
+    will access by name.
 
-    If fields is not `None`, the fields specified in `include_fields` are required, an
-    other fields are omitted.  If `include_fields` is `None`, all fields are included.
+    If `include_fields` is not `None`, only the fields specified in `include_fields`
+    will be included.  If `include_fields` is `None`, all fields are included.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -94,6 +94,30 @@ def _resolve_error_message_no_schema(status_code: int, text: str) -> tuple[str, 
             return f"{prefix}{text}", include_schema
 
 
+def _fetch_schema(client: httpx.Client, base_id: str, table_id_or_name: str) -> Any:
+    data = (
+        client.get(f"https://api.airtable.com/v0/meta/bases/{base_id}/tables")
+        .raise_for_status()
+        .json()
+    )
+    table_id_names = []
+    for table in data["tables"]:
+        table_id_names.append(f"{table['id']}({table['name']})")
+    schema = None
+    for table in data["tables"]:
+        if table["id"] == table_id_or_name:
+            schema = table["fields"]
+    if not schema:
+        for table in data["tables"]:
+            if table["name"] == table_id_or_name:
+                schema = table["fields"]
+    if not schema:
+        raise ValueError(
+            f"{table_id_or_name} not found in tables: {sorted(table_id_names)}"
+        )
+    return schema
+
+
 def _resolve_error_message(
     client: httpx.Client,
     base_id: str,
@@ -111,27 +135,7 @@ def _resolve_error_message(
     msg, include_schema = _resolve_error_message_no_schema(status_code, text)
     if include_schema:
         try:
-            data = (
-                client.get(f"https://api.airtable.com/v0/meta/bases/{base_id}/tables")
-                .raise_for_status()
-                .json()
-            )
-            table_id_names = []
-            for table in data["tables"]:
-                table_id_names.append(f"{table['id']}({table['name']})")
-            schema = None
-            for table in data["tables"]:
-                if table["id"] == table_id_or_name:
-                    schema = table["fields"]
-            if not schema:
-                for table in data["tables"]:
-                    if table["name"] == table_id_or_name:
-                        schema = table["fields"]
-            if not schema:
-                return (
-                    f"{msg}; {table_id_or_name} not found in "
-                    f"tables: {sorted(table_id_names)}"
-                )
+            schema = _fetch_schema(client, base_id, table_id_or_name)
             return f"{msg}; schema of table `{table_id_or_name}`: {json.dumps(schema)}"
         except Exception as e:
             return f"{msg}; (error fetching schema of {table_id_or_name}: {e})"
@@ -146,10 +150,18 @@ class AirtableRecord:
 
 
 def airtable_record_list(
-    base_id: AirtableBaseID, table_id: AirtableTableID
+    base_id: AirtableBaseID,
+    table_id: AirtableTableID,
+    include_fields: Optional[set[str]],
 ) -> list[AirtableRecord]:
     """
-    Return results of an Airtable `list records` API call.
+    Return results of an Airtable `list records` API call with the option of choosing
+    which fields to include in the returned records.  The include_fields fields are
+    required, so populate it ensure that the returned records have the fields you will
+    access by name.
+
+    If fields is not `None`, the fields specified in `include_fields` are required, an
+    other fields are omitted.  If `include_fields` is `None`, all fields are included.
     """
     with httpx.Client(
         transport=AugmentedTransport(actions_v0.authenticated_request_airtable)
@@ -157,17 +169,46 @@ def airtable_record_list(
         response = client.get(f"https://api.airtable.com/v0/{base_id.id}/{table_id.id}")
         if response.status_code != httpx.codes.OK:
             raise RuntimeError(
-                _resolve_error_message_no_schema(response.status_code, response.text)
+                _resolve_error_message(
+                    client,
+                    base_id.id,
+                    table_id.id,
+                    response.status_code,
+                    response.text,
+                )
             )
         data = response.json()
-    return [
-        AirtableRecord(
-            record_id=AirtableRecordID(record["id"]),
-            created_time=datetime.fromisoformat(record["createdTime"]),
-            fields=record["fields"],
-        )
-        for record in data["records"]
-    ]
+        records = []
+        for record in data["records"]:
+            if include_fields and not all(
+                field in record["fields"] for field in include_fields
+            ):
+                missing_fields = [
+                    field for field in include_fields if field not in record["fields"]
+                ]
+                msg = f"Record {record['id']} is missing fields: {missing_fields}"
+                try:
+                    schema = _fetch_schema(client, base_id.id, table_id.id)
+                    raise ValueError(
+                        f"{msg}; schema of table `{table_id.id}`: {json.dumps(schema)}"
+                    )
+                except Exception as e:
+                    raise ValueError(
+                        f"{msg}; (error fetching schema of {table_id.id}: {e})"
+                    )
+            filtered_fields = {
+                key: value
+                for key, value in record["fields"].items()
+                if not include_fields or key in include_fields
+            }
+            records.append(
+                AirtableRecord(
+                    record_id=AirtableRecordID(record["id"]),
+                    created_time=datetime.fromisoformat(record["createdTime"]),
+                    fields=filtered_fields,
+                )
+            )
+    return records
 
 
 def airtable_record_create(

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -152,7 +152,7 @@ class AirtableRecord:
 def airtable_record_list(
     base_id: AirtableBaseID,
     table_id: AirtableTableID,
-    include_fields: Optional[set[str]],
+    include_fields: Optional[set[str]] = None,
 ) -> list[AirtableRecord]:
     """
     Return results of an Airtable `list records` API call with the option of choosing


### PR DESCRIPTION
Allow specification of what fields to include when listing records.  This is a crude way for generated code to assert that the schema of a table is as it expects.

Airtable tables have field names.  When fetching data from Airtable, the generated code (possibly on its own or at your accidental direction) may try to access fields with names that do not exist, e.g.:

```python
    records: list[AirtableRecord] = airtable_record_list(base_id, table_id)
    person_values: List[str] = []
    for record in records:
        person_values.append(record.fields["First Name"])
```

where the records do not have a `"First Name"` field and instead have a `"Name"` field.

This is problematic because the code doesn't encounter an error until it tries to access the `"First Name"` field.  At that moment, it's hard to provide a useful error message, since it's a plain dict field access problem, and that (naively) raises a generic key error.  It's subsequently hard for users to work out that it's a schema problem, especially if it is a small typo, e.g. capitalization error.

With this change, we encourage generated code to specify which fields to include in the invocation of `airtable_record_list`.  In this, it would hopefully generate:

```python
    records: list[AirtableRecord] = airtable_record_list(base_id, table_id, include_fields={"First Name"})
    person_values: List[str] = []
    for record in records:
        person_values.append(record.fields["First Name"])
```

This code will raise an error in the call to `airtable_record_list`, and that error will include the schema of the table, so it's both easier for users to understand what has happened and for the workflow to (automatically) fix itself.

Closes [#2639](https://github.com/d8e-ai/alda/issues/2639).