### PR TITLE
Update airtable plugin

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -24,10 +24,10 @@ class AirtableTableID:
 
 @dataclass
 class AirtableViewID:
-    '''
-    Pass view id to other functions if it was successfully
+    """
+    You must pass view id to other functions if it was successfully
     extracted from the Airtable web UI URL.
-    '''
+    """
     id: str
 
 
@@ -38,7 +38,7 @@ class AirtableRecordID:
 
 def airtable_parse_ids_from_url(
     url: str,
-) -> Tuple[AirtableBaseID, Optional[AirtableTableID], Optional[AirtableRecordID], Optional[AirtableViewID]]:
+) -> Tuple[AirtableBaseID, Optional[AirtableTableID], Optional[AirtableViewID], Optional[AirtableRecordID]]:
     """
     Parses Airtable IDs from an Airtable web UI URL.  The minimum required URL format is
     https://airtable.com/{base_id}, with {base_id} being mandatory.  The URL may
@@ -64,13 +64,13 @@ def airtable_parse_ids_from_url(
     if match:
         base_id = match.group("base_id")
         table_id = match.group("table_id")
-        record_id = match.group("record_id")
         view_id = match.group("view_id")
+        record_id = match.group("record_id")
         return (
             AirtableBaseID(base_id),
             AirtableTableID(table_id) if table_id else None,
-            AirtableRecordID(record_id) if record_id else None,
             AirtableViewID(view_id) if view_id else None,
+            AirtableRecordID(record_id) if record_id else None,
         )
     else:
         raise ValueError(
@@ -172,14 +172,12 @@ def airtable_record_list(
 ) -> list[AirtableRecord]:
     """
     Returns the results of an Airtable `list records` API call, allowing selection of
-    specific fields to include in the returned records. Fields present in the schema
-    but not assigned a value will not be returned.
+    specific fields to include in the returned records.
 
     Important:
-    - If `include_fields` is specified (not `None`), only the fields listed in `include_fields`
-    will be included in the results.
-    - If `include_fields` is `None`, all fields that have assigned values will be included,
-    excluding any fields that are defined in the schema but are empty.
+    - If `include_fields` is not `None`, only the fields that are listed in `include_fields`
+    and have assigned values will be included in the results.
+    - If `include_fields` is `None`, all fields that have assigned values will be included.
     """
     post_body = {}
     if include_fields is not None:

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -167,8 +167,8 @@ class AirtableRecord:
 def airtable_record_list(
     base_id: AirtableBaseID,
     table_id: AirtableTableID,
-    include_fields: Optional[set[str]] = None,
     view_id: Optional[AirtableViewID] = None,
+    include_fields: Optional[set[str]] = None,
 ) -> list[AirtableRecord]:
     """
     Returns the results of an Airtable `list records` API call, allowing selection of

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -176,7 +176,7 @@ def airtable_record_list(
 
     Important:
     - If `include_fields` is not `None`, only the fields that are listed in `include_fields`
-    and have assigned values will be included in the results.
+    and have assigned values will be included.
     - If `include_fields` is `None`, all fields that have assigned values will be included.
     """
     post_body = {}

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -43,7 +43,7 @@ def airtable_parse_ids_from_url(
     Parses Airtable IDs from an Airtable web UI URL.  The minimum required URL format is
     https://airtable.com/{base_id}, with {base_id} being mandatory.  The URL may
     optionally include {table_id}, {view_id}, and {record_id} segments in this sequence,
-    but these are not required. Any segments or query parameters beyond the specified
+    but these are not required.  Any segments or query parameters beyond the specified
     record_id are ignored.
 
     table_id, view_id, and record_id are returned only if present in the URL;

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -165,8 +165,8 @@ class AirtableRecord:
 
 
 def airtable_record_list(
-    table_id: AirtableTableID,
     base_id: AirtableBaseID,
+    table_id: AirtableTableID,
     include_fields: Optional[set[str]] = None,
     view_id: Optional[AirtableViewID] = None,
 ) -> list[AirtableRecord]:


### PR DESCRIPTION
Update `airtable_record_list` to support retrieving records by `view_id`
- Context: Code gen usually generates code that processes data in the order it is returned by `airtable_record_list` and the result to the user looks like this:
![AirtableProfileLookup](https://github.com/d8e-ai/lutra-plugin/assets/349656/46ddc432-77a5-47f7-a10a-a48c39ac98f2)

Update `airtable_record_list` docstring to be more accurate regarding what is returned in fields
- Code gen would sometimes generate code that checks for the existence of a field in the record:
<img width="598" alt="Screenshot 2024-02-12 at 10 35 41 AM" src="https://github.com/d8e-ai/lutra-plugin/assets/349656/71e16750-da10-4321-aa48-949fa397ab54">

See also: https://lutra.ai/run-debug/workflows/deW0k5xWHXs/018d8b5a-0319-82f7-9855-8e79ff87e627

- Updating the docstring to let code gen know that fields aren't always returned.
