### PR TITLE
Add github issues and comments fetching actions, and a test.

### DIFF
--- a/github/plugin.py
+++ b/github/plugin.py
@@ -8,7 +8,7 @@ from lutraai.augmented_request_client import AugmentedTransport
 
 
 @dataclass
-class PullRequest:
+class GitHubPullRequest:
     id: int
     html_url: str
     created_at: datetime
@@ -30,7 +30,7 @@ def github_pulls(
     sort: Literal["created", "updated", "popularity", "long-running"] = "created",
     sort_direction: Literal["asc", "desc"] = "desc",
     page: int = 1,
-) -> list[PullRequest]:
+) -> list[GitHubPullRequest]:
     """
     Returns results of a GitHub `pulls` API call.
 
@@ -64,7 +64,7 @@ def github_pulls(
             .json()
         )
     pull_requests = [
-        PullRequest(
+        GitHubPullRequest(
             id=obj["id"],
             html_url=obj["html_url"],
             created_at=datetime.fromisoformat(obj["created_at"]),

--- a/github/plugin.py
+++ b/github/plugin.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 import httpx
+
 from lutraai.augmented_request_client import AugmentedTransport
 
 
@@ -47,7 +48,7 @@ def github_pulls(
 
     """
     with httpx.Client(
-        transport=AugmentedTransport(actions_v0.authenticated_request_github)
+        transport=AugmentedTransport(actions_v0.authenticated_request_github),
     ) as client:
         response_json = (
             client.get(
@@ -88,3 +89,128 @@ def github_pulls(
         for obj in response_json
     ]
     return pull_requests
+
+
+@dataclass
+class GitHubIssue:
+    id: int
+    issue_number: int
+    issue_type: Literal["issue", "pull_request"]
+    html_url: str
+    created_at: datetime
+    updated_at: datetime
+    closed_at: Optional[datetime]
+    title: str
+    state: str
+    body: str
+    user_id: int
+    user_login: str
+    labels: list[str]
+
+
+def github_issues(
+    owner: str,
+    repo: str,
+    state: Literal["open", "closed", "all"] = "open",
+    sort: Literal["created", "updated", "comments"] = "created",
+    sort_direction: Literal["asc", "desc"] = "desc",
+    page: int = 1,
+) -> list[GitHubIssue]:
+    """
+    Returns results of a GitHub `issues` API call.
+
+    Issues can be either issues or pull requests. This function returns both.
+
+    Returns a paginated listing of issues in the given `repo` owned by `owner`.
+    Each page has at most 30 results. To get more results, increment the `page` and
+    call this function again.
+
+    Parameters:
+        owner: the owner of the repository.
+        repo: the repository name.
+        state: the state of the issues to fetch from GitHub.
+        sort: by what to sort results.
+        sort_direction: the direction of the sort.
+        page: the page of results to return. Each page has at most 30 results.
+    """
+    with httpx.Client(
+        transport=AugmentedTransport(actions_v0.authenticated_request_github)
+    ) as client:
+        response_json = (
+            client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/issues",
+                params={
+                    "state": state,
+                    "page": page,
+                    "sort": sort,
+                    "direction": sort_direction,
+                },
+            )
+            .raise_for_status()
+            .json()
+        )
+    issues = [
+        GitHubIssue(
+            id=obj["id"],
+            html_url=obj["html_url"],
+            issue_number=obj["number"],
+            issue_type="pull_request" if "pull_request" in obj else "issue",
+            created_at=datetime.fromisoformat(obj["created_at"]),
+            updated_at=datetime.fromisoformat(obj["updated_at"]),
+            closed_at=(
+                datetime.fromisoformat(obj["closed_at"])
+                if obj.get("closed_at")
+                else None
+            ),
+            title=obj["title"],
+            state=obj["state"],
+            body=obj.get("body", ""),
+            user_id=obj["user"]["id"],
+            user_login=obj["user"]["login"],
+            labels=[
+                label["name"] for label in obj.get("labels", [])
+            ],  # Extracting label names
+        )
+        for obj in response_json
+    ]
+    return issues
+
+
+@dataclass
+class GitHubComment:
+    id: int
+    body: str
+    user_id: int
+    user_login: str
+    created_at: datetime
+    updated_at: datetime
+
+
+def github_comments(owner: str, repo: str, issue_number: int) -> List[GitHubComment]:
+    """
+    Fetches comments for a specific issue by its number.
+    """
+    with httpx.Client(
+        transport=AugmentedTransport(actions_v0.authenticated_request_github)
+    ) as client:
+        response_json = (
+            client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments"
+            )
+            .raise_for_status()
+            .json()
+        )
+
+    comments = [
+        GitHubComment(
+            id=comment["id"],
+            body=comment["body"],
+            user_id=comment["user"]["id"],
+            user_login=comment["user"]["login"],
+            created_at=datetime.fromisoformat(comment["created_at"]),
+            updated_at=datetime.fromisoformat(comment["updated_at"]),
+        )
+        for comment in response_json
+    ]
+
+    return comments

--- a/github/plugin.toml
+++ b/github/plugin.toml
@@ -1,5 +1,5 @@
 name = "GitHub"
-description = "Get information about GitHub pull requests."
+description = "Get information about GitHub pull requests and issues."
 logo_url = "/assets/logos/github-mark.svg"
 
 [[required_actions]]

--- a/github/plugin_test.py
+++ b/github/plugin_test.py
@@ -1,0 +1,82 @@
+"""Tests for the github plugin.
+
+These tests hit a real GitHub repo, so they require an internet connection
+and should not be run excessively to avoid rate limit issues.
+"""
+
+import types
+import unittest
+from unittest.mock import patch
+
+import httpx
+import plugin
+
+# Create a module that has a symbol called authenticated_request_github
+actions_v0 = types.ModuleType("actions_v0")
+setattr(actions_v0, "authenticated_request_github", lambda: None)
+plugin.__dict__["actions_v0"] = actions_v0
+
+
+# Create a custom httpx.Client class that ignores the 'transport' argument.
+class MyTestHttpxClient(httpx.Client):
+    def __init__(self, *args, **kwargs):
+        kwargs.pop("transport", None)
+        super().__init__(*args, **kwargs)
+
+
+class TestPlugin(unittest.TestCase):
+    @patch("plugin.httpx.Client", new=MyTestHttpxClient)
+    def _test_github_pulls(self):
+        # Pull this repo's Pulls (including closed ones), sorted by creation date
+        # to get the first Pull Request ever created for this repo.
+        result = plugin.github_pulls(
+            owner="d8e-ai",
+            repo="lutra-plugin",
+            state="all",
+            sort="created",
+            sort_direction="asc",
+            page=1,
+        )
+        self.assertGreater(len(result), 0)
+        self.assertEqual(
+            result[0].html_url, "https://github.com/d8e-ai/lutra-plugin/pull/1"
+        )
+        self.assertEqual(result[0].title, "Rename to Lutra")
+
+    @patch("plugin.httpx.Client", new=MyTestHttpxClient)
+    def _test_github_issues(self):
+        page = 1
+        while True:
+            result = plugin.github_issues(
+                owner="d8e-ai",
+                repo="lutra-plugin",
+                state="all",
+                sort="created",
+                sort_direction="asc",
+                page=page,
+            )
+            result = [x for x in result if x.issue_type == "issue"]
+            if not result:
+                page += 1
+                continue
+
+            self.assertGreater(len(result), 0)
+            self.assertEqual(
+                result[0].html_url, "https://github.com/d8e-ai/lutra-plugin/issues/45"
+            )
+            self.assertEqual(result[0].title, "Make plugins more testable")
+            break
+
+    @patch("plugin.httpx.Client", new=MyTestHttpxClient)
+    def test_github_comment(self):
+        result = plugin.github_comments(
+            owner="d8e-ai",
+            repo="lutra-plugin",
+            issue_number=44,
+        )
+        print(result)
+        self.assertGreater(len(result), 0)
+        self.assertEqual(
+            result[0].body,
+            "@jcharum @vrv let me know if these addressed your concerns :)",
+        )


### PR DESCRIPTION
It's a bit tricky to test these actions because they require an authenticated wrapper.  However, the test mocks / injects a fake for the symbols / implementation to get things working, and pointing the APIs at public resources still works for the purposes of a test.  Though this hits a real API so is subject to rate limits from GitHub.  But it's okay for one-off testing (not CI, yet).

Let me know what you think or what alternatives might be worth pursuing!