### PR TITLE
Update airtable_record_list function:

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -172,12 +172,9 @@ def airtable_record_list(
 ) -> list[AirtableRecord]:
     """
     Returns the results of an Airtable `list records` API call, allowing selection of
-    specific fields to include in the returned records.
-
-    Important:
-    - If `include_fields` is not `None`, only the fields that are listed in `include_fields`
-    and have assigned values will be included.
-    - If `include_fields` is `None`, all fields that have assigned values will be included.
+    specific fields to include in the returned records. You must populate
+    include_fields with necessary fields to access data by name in returned records.
+    Unset fields in Airtable are are excluded from the records, but can be set during a patch call.
     """
     post_body = {}
     if include_fields is not None:


### PR DESCRIPTION
- Update prompt to make sure that an empty set isn't passed to include_fields when calling the function
- Update prompt to notify code_gen that a field that is unset will be excluded from the returned records

Workflow that used include_field because the prompt specified the fields: https://lutra.ai/workflows/bWYO7NR-gkA
![Screenshot 2024-02-28 at 9 59 57 AM](https://github.com/d8e-ai/lutra-plugin/assets/349656/b1a3cfb4-b310-4d95-8be9-a28b3187d16c)

Workflow that did not use the include_field because the we wanted to just return all the fields in a markdown table: https://lutra.ai/workflows/23TiTTwh5Qs
![Screenshot 2024-02-28 at 10 01 00 AM](https://github.com/d8e-ai/lutra-plugin/assets/349656/76691b3f-ff45-4bf8-b2b7-1889558eb939)
