### PR TITLE
Tweak airtable_record_list docstring

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -174,7 +174,7 @@ def airtable_record_list(
     Returns the results of an Airtable `list records` API call, allowing selection of
     specific fields to include in the returned records. You must populate
     include_fields with necessary fields to access data by name in returned records.
-    Unset fields in Airtable are are excluded from the records, but can be set during a patch call.
+    Before accessing a field's value in the returned record, you MUST check for the existence of the field.
     """
     post_body = {}
     if include_fields is not None:
@@ -256,6 +256,7 @@ def airtable_record_update_patch(
 ) -> None:
     """
     Update a record using the Airtable `update record` API call with a PATCH and override the fields it is patching.
+    You do not need to check for the existence of the field before setting it.
 
     If typecast is True, Airtable will try to convert the value to the appropriate cell value.
     """

--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -256,7 +256,7 @@ def airtable_record_update_patch(
 ) -> None:
     """
     Update a record using the Airtable `update record` API call with a PATCH and override the fields it is patching.
-    You do not need to check for the existence of the field before setting it.
+    You are able to update fields which may not be present.
 
     If typecast is True, Airtable will try to convert the value to the appropriate cell value.
     """


### PR DESCRIPTION
Encourage code_gen to check for existence of fields before using a field. airtable fields that are unset do not get returned. This docstring tweak encourages code_gen to check for the existence of the field before accessing the value by the key.

Workflow affected: https://lutra.ai/workflows/h9FKkobgykU/versions/V1

Generated code snippet after docstring tweak:
```
        # Get the attraction name
        attraction_name: str = record.fields.get("ATTRACTION_NAME", "")

        # Search for the genre and sub-genre
        try:
            result: SearchResult = _search_genre_subgenre(attraction_name)
        except Exception as e:
            print(f"Error searching for {attraction_name}: {str(e)}")
            continue

        # Update the record in Airtable
        fields: Dict[str, Any] = {}
        if result.is_sports:
            fields["LutraGenre"] = "Sports"
            if result.sport_type:
                fields["LutraSubGenre"] = result.sport_type
        else:
            if result.genre:
                fields["LutraGenre"] = result.genre
            if result.sub_genre:  
                fields["LutraSubGenre"] = result.sub_genre

        if fields:
            try:
                airtable_record_update_patch(AirtableBaseID(base_id), AirtableTableID(table_id), AirtableRecordID(record.record_id.id), fields)
                print(f"Updated {attraction_name} with {fields}")
            except Exception as e:
                print(f"Error updating {attraction_name}: {str(e)}")
```