### PR TITLE
github: Handle null pull request body field

### DIFF
--- a/github/plugin.py
+++ b/github/plugin.py
@@ -82,7 +82,7 @@ def github_pulls(
             title=obj["title"],
             state=obj["state"],
             draft=obj["draft"],
-            body=obj.get("body", ""),
+            body=obj.get("body") or "",
             user_id=obj["user"]["id"],
             user_login=obj["user"]["login"],
         )


### PR DESCRIPTION
The `body` field can be `null`.  See [documentation](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests).