### PR TITLE
add sort and filter_by_formula args to airtable_record_list

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -200,8 +200,6 @@ def airtable_record_list(
     specific fields to include in the returned records and handling pagination.
     You must populate include_fields with necessary fields to access data by name in returned records.
     Before accessing a field's value in the returned record, you MUST check for the existence of the field.
-    Hint: To update all rows in a table, prefer repeating a call with a `filter_by_formula` that selects
-    non-updated rows over using `pagination_token`.
 
     Returns:
       - A list of AirtableRecord objects.


### PR DESCRIPTION
These are useful for incremental data sync and data processing:
* When the task is to sync data from an external source into airtable, there is often a way to query the external source for "records added after xxx". With the `sort` argument, you can get the "latest" record in the airtable, according to whatever task-specific field is right for querying the external source. Lutra seems to already understand this pretty well, in my own workflow all I had to say was "change it to only sync runs later than the latest run in the table" and it did the right thing.
* When the task is to fill in field(s), you can use `filter_by_formula` to find records that need their field filled in. This is better than using pagination, because it doesn't time out, and because it lets you resume from where you left off faster than paginating through a bunch of already-processed records. Lutra seems to not understand this very well. It prefers to use pagination unless you very explicitly tell it to use `filter_by_formula`. This PR at least makes this possible, and in the future we could tune docstrings if we wanted to make Lutra more likely to do it this way by default.

Lutra seems to understand how to use these arguments without any information in the docstring. It probably knows about the Airtable API. It always passed appropriate values when I was playing with it.

I am a bit worried that with all these arguments Lutra will start getting confused and doing wrong things. But I played with it a bit, and it never tried to use these arguments unless I asked it for something really specific that needed them.