### PR TITLE
airtable schema observe

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -152,6 +152,7 @@ def _safedel(v: dict[str, Any], k: str):
     with suppress(KeyError):
         del v[k]
 
+
 @dataclass
 class AirtableFieldSchema:
     name: str


### PR DESCRIPTION
* Adds `airtable_get_base_schema` to allow chat to see the table schemas before operating on the tables.
* Does the same schema processing that we had in our existing airtable schema observe.

There are some things I was unsure about.
* Should I even define dataclasses for the schema? I could just return the whole JSON response as a `Any` or `dict[str, Any]`. I did try this, and it caused snippets to sometimes assume incorrect things about the response format, like looking for table schemas in `schema[table_id]`, and sometimes it even tried to get information about the schema out of it using `data_extractor`.
* Same question about the schemaless `options: dict[str, Any]` I have in my dataclass. Except for this one, I decided to keep it schemaless because (1) it seems to cause fewer problems, and (2) the actual schema is pretty massive and complicated.