### PR TITLE
Assign default to thread_ts

### DIFF
--- a/slack/plugin.py
+++ b/slack/plugin.py
@@ -42,7 +42,7 @@ def _with_mentions(users: list[SlackUser], message: str) -> str:
 
 @purpose("Send a message to a channel.")
 def slack_send_message_to_channel(
-    channel: str, message: str, thread_ts: Optional[str]
+    channel: str, message: str, thread_ts: Optional[str] = None
 ) -> None:
     """
     Send a message to a channel by channel name or ID.


### PR DESCRIPTION
Updating slack_send_message_to_channel to assign a default value to the thread_ts argument.