### PR TITLE
hubspot: Delete dataclass methods, as they have no effect

### DIFF
--- a/hubspot/plugin.py
+++ b/hubspot/plugin.py
@@ -89,63 +89,6 @@ class HubSpotPropertyValue:
 
     value: Any
 
-    # Define dunder conversion methods in case casting is used.
-    def __str__(self) -> str:
-        return self.as_str()
-
-    def __int__(self) -> int:
-        return self.as_int()
-
-    def __float__(self) -> float:
-        return self.as_float()
-
-    def as_datetime(self) -> datetime:
-        match self.value:
-            case datetime():
-                return self.value
-            case str():
-                return datetime.fromisoformat(self.value)
-            case _:
-                raise
-
-    def as_str(self) -> str:
-        match self.value:
-            case str():
-                return self.value
-            case _:
-                # int and float are also valid strings
-                return str(self.value)
-
-    def as_int(self) -> int:
-        match self.value:
-            case int():
-                return self.value
-            case float():
-                return int(self.value)
-            case str():
-                try:
-                    # Parse the string as an int
-                    return int(self.value)
-                except ValueError:
-                    if self.value.strip() == "":
-                        return 0
-                    raise
-
-    def as_float(self) -> float:
-        match self.value:
-            case float():
-                return self.value
-            case int():
-                return float(self.value)
-            case str():
-                try:
-                    # Parse the string as a float
-                    return float(self.value)
-                except ValueError:
-                    if self.value.strip() == "":
-                        return 0.0
-                    raise
-
 
 @dataclass
 class HubSpotContact:

--- a/hubspot/plugin.py
+++ b/hubspot/plugin.py
@@ -80,10 +80,6 @@ def _get_all_property_names(schema: _HubSpotPropertiesSchema) -> list[str]:
 class HubSpotPropertyValue:
     """A property value from HubSpot.
 
-    as_* methods can raise a ValueError if the value cannot be safely converted to the appropriate type.
-
-    Empty strings are treated as 0 for int and float conversions.
-
     `value` property can only be a string, int, float, or datetime.
     """
 


### PR DESCRIPTION
Plugin dataclass methods are not propagated/available during evaluation, so delete them to avoid the illusion.

(I will separately prevent dataclass methods from being saved in the first place).

We could also choose to support them, but given that it doesn't seem to be a problem, I am not worrying about it now.