### PR TITLE
Update HubSpot search actions

### DIFF
--- a/hubspot/plugin.py
+++ b/hubspot/plugin.py
@@ -507,6 +507,25 @@ def _convert_and_groups_to_filter_groups(
             filters.append(filter)
 
         filter_groups.append({"filters": filters})
+
+    # Running validation
+    validation_err_msgs = []
+
+    total_count = sum(len(filter_group.get("filters")) for filter_group in filter_groups)
+    if total_count > 18:
+        validation_err_msgs.append(f"Too many conditions across all or_groups (count: {total_count}, max allowed: 18).")
+
+    if any(len(filter_group.get("filters")) > 6 for filter_group in filter_groups):
+        validation_err_msgs.append("Too many conditions in AndGroup (max allowed: 6).")
+
+    if len(filter_groups) > 5:
+        validation_err_msgs.append(
+            f"Too many or_groups (count: {len(filter_groups)}, max allowed: 5)"
+        )
+
+    if validation_err_msgs:
+        raise RuntimeError(" ".join(validation_err_msgs))
+
     return filter_groups
 
 

--- a/hubspot/plugin.py
+++ b/hubspot/plugin.py
@@ -504,7 +504,7 @@ class FilterGroup(TypedDict):
 
 def _convert_and_groups_to_filter_groups(
     and_groups: List[AndGroup], schema: _HubSpotPropertiesSchema
-) -> List[dict[str, Any]]:
+) -> List[FilterGroup]:
     """
     Convert our internal AND groups structure to HubSpot's filter groups format.
     Each AND group becomes a filter group where all conditions must match.

--- a/hubspot/plugin.py
+++ b/hubspot/plugin.py
@@ -549,7 +549,7 @@ def _convert_and_groups_to_filter_groups(
         )
 
     if validation_err_msgs:
-        raise RuntimeError(" ".join(validation_err_msgs))
+        raise RuntimeError("\n\n".join(validation_err_msgs))
 
     return filter_groups
 

--- a/hubspot/plugin.py
+++ b/hubspot/plugin.py
@@ -510,6 +510,7 @@ def _convert_and_groups_to_filter_groups(
     return filter_groups
 
 
+@purpose("Search contacts")
 async def hubspot_search_contacts(
     query: SearchQuery,
     pagination_token: Optional[HubSpotPaginationToken] = None,


### PR DESCRIPTION
Update various search actions (contacts, companies, deals) to return results that match different IDS.

## Change
- Support OR queries in search (OR-of-ANDs boolean logic).

## Tests
### Prompt to fetch objects using multiple IDs 
```
Get the hubspot {insert object type} with the list of ids: {list of ids}

Use hubspot_search_{object_type}
```
