### PR TITLE
Add Airtable batch create records API.

### DIFF
--- a/airtable/plugin.py
+++ b/airtable/plugin.py
@@ -11,7 +11,7 @@ import httpx
 import tenacity
 
 from lutraai.augmented_request_client import AugmentedTransport
-from lutraai.decorator import purpose
+from lutraai.decorator import deprecated, purpose
 
 
 @dataclass
@@ -363,6 +363,7 @@ def airtable_record_list(
     ], next_token
 
 
+@deprecated("Subsumed by `airtable_records_create`.")
 @purpose("Create a record.")
 def airtable_record_create(
     base_id: AirtableBaseID,
@@ -416,9 +417,6 @@ def airtable_records_create(
     """
     Create multiple records using the Airtable `create records` API call with a POST.
     Takes a list of field dictionaries and creates a record for each one.
-
-    Prefer to use this over `airtable_record_create` since this takes batches of records
-    and is more efficient.
 
     If typecast is True, Airtable will try to convert the values to the appropriate cell values.
     """


### PR DESCRIPTION
Adds Airtable batch record creation.

Deprecate the old single-record API -- available for old code, but not new generations.

Implementation batches internally in up to 10 records as per the limit.  TODO to make each batch in async parallel...

In the future we can implement batch updating as well.
