### PR TITLE
slack: Rename Lutra bot to "Lutra"

### DIFF
--- a/slack/plugin.py
+++ b/slack/plugin.py
@@ -8,7 +8,7 @@ import httpx
 from lutraai.augmented_request_client import AugmentedTransport
 from lutraai.decorator import purpose
 
-_BOT_NAME = "Lutra Slack Bot"
+_BOT_NAME = "Lutra"
 
 
 @dataclass


### PR DESCRIPTION
It looks nicer and is consistent with the "GitHub" and "Stripe" bots.

I've already made the change for the actual Slack app.  This changes a help/error message to be consistent.