### PR TITLE
migrate the rest of our source-controlled plugins to inline auth

### DIFF
--- a/airtable/plugin.toml
+++ b/airtable/plugin.toml
@@ -2,9 +2,3 @@ name = "Airtable"
 description = "List and update records in Airtable."
 logo_url = "https://storage.googleapis.com/lutra-2407-public/797288d8ecec44ba8ecd08823d8ccce1f18290f7a4968a982d8f2bfcfa6294a0.svg"
 observable_source_types = ["airtable_view"]
-
-[[required_actions]]
-action_reference_type = "augmented_request"
-augmented_request_configuration_id = "b21a4545-20dc-4672-9418-8a5c220f13b9"
-# local environment
-# augmented_request_configuration_id = "25cd3564-d9c7-4828-a2cc-48320f0375ea"

--- a/apollo/plugin.toml
+++ b/apollo/plugin.toml
@@ -1,8 +1,3 @@
 name = "Apollo"
 description = "Fetch enrichment data from Apollo."
 logo_url = "https://storage.googleapis.com/lutra-2407-public/26d957a9dad8cb12ee51ef686fe4d38f64e924c4cfd8dd94818fa0d5070d9617.svg"
-
-[[required_actions]]
-action_reference_type = "augmented_request"
-augmented_request_configuration_id = "c6a1be36-5539-4517-aec9-31a516bd5b62"
-

--- a/github/plugin.toml
+++ b/github/plugin.toml
@@ -1,7 +1,3 @@
 name = "GitHub"
 description = "Get information about GitHub pull requests and issues."
 logo_url = "https://storage.googleapis.com/lutra-2407-public/7a0dd11e373830a51a565de9fed4a985707c67ccd390f9ae4946a152303ea676.svg"
-
-[[required_actions]]
-action_reference_type = "augmented_request"
-augmented_request_configuration_id = "2598dbb1-c887-4151-a833-78760eebf6bd"

--- a/hubspot/plugin.toml
+++ b/hubspot/plugin.toml
@@ -1,7 +1,3 @@
 name = "HubSpot"
 description = "Manage your HubSpot Contacts."
 logo_url = "https://storage.googleapis.com/lutra-2407-public/14e0f204508b6be2d14f53aef66c6915f2be79263a5f6e4bc16883f0da7c3464.svg"
-
-[[required_actions]]
-action_reference_type = "augmented_request"
-augmented_request_configuration_id = "aa74e3ef-c3c4-4fa0-b407-343608c431aa"

--- a/slack/plugin.py
+++ b/slack/plugin.py
@@ -43,8 +43,9 @@ bot_client = AuthenticatedAsyncClient(
             access_type="offline",
             profile_id_field="bot_id",
             logo="https://storage.googleapis.com/lutra-2407-public/847d981628d283c576840274eb7631f331a06d398329eb17755967017bb4595f.svg",
-            auth_header_key="Authorization",
-            auth_header_value="Bearer {api_key}",
+            header_auth={
+                "Authorization": "Bearer {api_key}",
+            },
             refresh_token_config=InternalRefreshTokenConfig(
                 auth_refresh_type="form",
                 body_fields={
@@ -94,8 +95,9 @@ user_client = AuthenticatedAsyncClient(
             access_type="offline",
             profile_id_field="user_id",
             logo="https://storage.googleapis.com/lutra-2407-public/847d981628d283c576840274eb7631f331a06d398329eb17755967017bb4595f.svg",
-            auth_header_key="Authorization",
-            auth_header_value="Bearer {api_key}",
+            header_auth={
+                "Authorization": "Bearer {api_key}",
+            },
             refresh_token_config=InternalRefreshTokenConfig(
                 auth_refresh_type="form",
                 body_fields={

--- a/zoom/plugin.toml
+++ b/zoom/plugin.toml
@@ -1,7 +1,3 @@
 name = "Zoom"
 description = "Call Zoom API."
 logo_url = "https://storage.googleapis.com/lutra-2407-public/400ce0579863533a48d310b35811638393dbc50d4fbed9e5045ee43ceaa3f8ac.svg"
-
-[[required_actions]]
-action_reference_type = "augmented_request"
-augmented_request_configuration_id = "5874e9f1-e629-4844-96de-5f8ba2df0742"


### PR DESCRIPTION
Test and release "plan":
* airtable: I tested one action locally, and I will test one action after importing to prod.
* apollo: I won't test anything because I don't have an api key. This seems fine because this plugin doesn't get much usage.
* github: I tested one action locally, and I will test one action after importing to prod.
* hubspot: I will test one action after importing to prod. (It doesn't work locally I think).
* slack: I tested one action locally, and I will test one action after importing to prod.
* zoom: I won't test or import anything because this is not live in prod right now.